### PR TITLE
Improve mobile header and action controls responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,20 @@
 </head>
 <body>
     <header id="floating-header" class="app-header">
-        <div class="logo">📚 StudyFlow</div>
-        <div class="header-sections">
+        <div class="header-top">
+            <div class="logo">📚 StudyFlow</div>
+            <button
+                id="header-toggle"
+                class="header-toggle"
+                type="button"
+                aria-expanded="false"
+                aria-controls="header-sections"
+            >
+                <span class="sr-only">Toggle header tools</span>
+                <span aria-hidden="true">☰</span>
+            </button>
+        </div>
+        <div id="header-sections" class="header-sections">
             <div class="header-main">
                 <div class="test-select-group">
                     <label class="input-label" for="test-select">Choose a Test</label>
@@ -165,10 +177,22 @@
         </div>
     </main>
 
-    <div id="floating-actions">
-        <button id="submit-test" class="btn btn-primary">Submit Test</button>
-        <button id="reset-test" class="btn btn-secondary">Reset Test</button>
-        <button id="download-results" class="btn btn-tertiary">Download Results as PDF</button>
+    <div id="floating-actions" class="floating-actions">
+        <button
+            id="floating-actions-toggle"
+            class="floating-actions-toggle"
+            type="button"
+            aria-expanded="false"
+            aria-controls="floating-actions-panel"
+        >
+            <span class="sr-only">Toggle quick actions</span>
+            <span aria-hidden="true">⚙️</span>
+        </button>
+        <div id="floating-actions-panel" class="floating-actions-panel">
+            <button id="submit-test" class="btn btn-primary">Submit Test</button>
+            <button id="reset-test" class="btn btn-secondary">Reset Test</button>
+            <button id="download-results" class="btn btn-tertiary">Download Results as PDF</button>
+        </div>
     </div>
 
     <button id="back-to-top" title="Go to top">&#8679;</button>

--- a/script.js
+++ b/script.js
@@ -67,6 +67,17 @@ document.addEventListener("DOMContentLoaded", function () {
   const downloadReportButton = document.getElementById("download-report");
   const progressBarElement = document.getElementById("progress-bar");
   const progressTextElement = document.getElementById("progress-text");
+  const headerElement = document.getElementById("floating-header");
+  const headerToggleButton = document.getElementById("header-toggle");
+  const floatingActionsContainer = document.getElementById("floating-actions");
+  const floatingActionsToggle = document.getElementById(
+    "floating-actions-toggle"
+  );
+
+  const MOBILE_BREAKPOINT = 768;
+  let lastViewportIsMobile = window.innerWidth <= MOBILE_BREAKPOINT;
+  let headerCollapsed = window.innerWidth <= MOBILE_BREAKPOINT;
+  let actionsCollapsed = window.innerWidth <= MOBILE_BREAKPOINT;
 
   if (flashcardsGrid) {
     flashcardsGrid.classList.add("hidden");
@@ -178,6 +189,65 @@ document.addEventListener("DOMContentLoaded", function () {
   function updateStatsDisplay() {
     updateStatsPanel();
     updateGamification();
+  }
+
+  function isMobileViewport() {
+    return window.innerWidth <= MOBILE_BREAKPOINT;
+  }
+
+  function syncHeaderToggleState() {
+    if (!headerElement || !headerToggleButton) {
+      return;
+    }
+
+    if (!isMobileViewport()) {
+      headerCollapsed = false;
+      headerElement.classList.remove("collapsed");
+      headerToggleButton.setAttribute("aria-expanded", "true");
+      return;
+    }
+
+    headerElement.classList.toggle("collapsed", headerCollapsed);
+    headerToggleButton.setAttribute(
+      "aria-expanded",
+      headerCollapsed ? "false" : "true"
+    );
+  }
+
+  function syncFloatingActionsState() {
+    if (!floatingActionsContainer || !floatingActionsToggle) {
+      return;
+    }
+
+    if (!isMobileViewport()) {
+      actionsCollapsed = false;
+      floatingActionsContainer.classList.remove("collapsed");
+      floatingActionsToggle.setAttribute("aria-expanded", "true");
+      return;
+    }
+
+    floatingActionsContainer.classList.toggle("collapsed", actionsCollapsed);
+    floatingActionsToggle.setAttribute(
+      "aria-expanded",
+      actionsCollapsed ? "false" : "true"
+    );
+  }
+
+  function handleResponsiveState() {
+    const isMobile = isMobileViewport();
+
+    if (isMobile && !lastViewportIsMobile) {
+      headerCollapsed = true;
+      actionsCollapsed = true;
+    } else if (!isMobile && lastViewportIsMobile) {
+      headerCollapsed = false;
+      actionsCollapsed = false;
+    }
+
+    syncHeaderToggleState();
+    syncFloatingActionsState();
+
+    lastViewportIsMobile = isMobile;
   }
 
   function resetStats() {
@@ -318,6 +388,30 @@ document.addEventListener("DOMContentLoaded", function () {
   if (statsResetButton) {
     statsResetButton.addEventListener("click", resetStats);
   }
+
+  handleResponsiveState();
+
+  if (headerToggleButton) {
+    headerToggleButton.addEventListener("click", () => {
+      if (!isMobileViewport()) {
+        return;
+      }
+      headerCollapsed = !headerCollapsed;
+      syncHeaderToggleState();
+    });
+  }
+
+  if (floatingActionsToggle) {
+    floatingActionsToggle.addEventListener("click", () => {
+      if (!isMobileViewport()) {
+        return;
+      }
+      actionsCollapsed = !actionsCollapsed;
+      syncFloatingActionsState();
+    });
+  }
+
+  window.addEventListener("resize", handleResponsiveState);
 
   loadStreak();
   loadStats();

--- a/styles.css
+++ b/styles.css
@@ -79,9 +79,37 @@ button {
     border-bottom: 1px solid var(--border-color);
 }
 
+.header-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+}
+
 .logo {
     font-size: 1.5rem;
     font-weight: 700;
+    color: var(--accent-color);
+}
+
+.header-toggle {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: 1px solid var(--border-color);
+    background: var(--surface-color);
+    color: var(--text-color);
+    cursor: pointer;
+    box-shadow: var(--shadow);
+    transition: var(--transition);
+}
+
+.header-toggle:focus-visible,
+.header-toggle:hover {
+    border-color: var(--accent-color);
     color: var(--accent-color);
 }
 
@@ -92,6 +120,18 @@ button {
     gap: 1.5rem;
     flex-wrap: wrap;
     width: 100%;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 .header-main {
@@ -190,7 +230,13 @@ button {
     font-weight: 600;
     color: var(--accent-color);
     min-width: 110px;
-    text-align: right;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.65rem 1rem;
+    border-radius: var(--radius-sm);
+    background: var(--subtle-surface);
+    border: 1px solid var(--border-color);
 }
 
 .header-actions {
@@ -736,12 +782,44 @@ body.study-mode-active .question {
     bottom: 2rem;
     display: flex;
     flex-direction: column;
-    gap: 0.6rem;
+    align-items: flex-end;
+    gap: 0.5rem;
     z-index: 90;
 }
 
-#floating-actions .btn {
+.floating-actions-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    align-items: stretch;
+}
+
+.floating-actions-panel .btn {
     box-shadow: var(--shadow);
+}
+
+.floating-actions-toggle {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    border: none;
+    background: var(--accent-color);
+    color: #ffffff;
+    cursor: pointer;
+    box-shadow: var(--shadow);
+    transition: var(--transition);
+}
+
+.floating-actions-toggle:focus-visible,
+.floating-actions-toggle:hover {
+    filter: brightness(0.95);
+}
+
+.floating-actions.collapsed .floating-actions-panel {
+    display: none;
 }
 
 #back-to-top {
@@ -822,6 +900,14 @@ body.study-mode-active .question {
 }
 
 @media (max-width: 768px) {
+    .header-toggle {
+        display: inline-flex;
+    }
+
+    #floating-header.collapsed #header-sections {
+        display: none;
+    }
+
     .header-controls {
         align-items: stretch;
         gap: 1rem;
@@ -835,7 +921,7 @@ body.study-mode-active .question {
     }
 
     .timer-display {
-        text-align: left;
+        justify-content: flex-start;
     }
 
     .header-actions {
@@ -847,6 +933,21 @@ body.study-mode-active .question {
         position: fixed;
         right: 1rem;
         bottom: 1rem;
+        gap: 0.5rem;
+    }
+
+    .floating-actions-toggle {
+        display: inline-flex;
+    }
+
+    #floating-actions.collapsed .floating-actions-toggle {
+        background: var(--surface-color);
+        color: var(--accent-color);
+        border: 1px solid var(--accent-color);
+    }
+
+    .floating-actions-panel .btn {
+        width: 100%;
     }
 
     .gamification {


### PR DESCRIPTION
## Summary
- add a collapsible toggle for the header tools and mobile quick-action menu
- refine responsive styles so the timer pill and floating actions align cleanly on desktop and mobile

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3cab5a308832e80d8fbadda04e27f